### PR TITLE
Mistyping `opt.datset`

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -71,7 +71,7 @@ loader.ix_to_word = infos['vocab']
 
 
 # Set sample options
-opt.datset = opt.input_json
+opt.dataset = opt.input_json
 loss, split_predictions, lang_stats = eval_utils.eval_split(model, crit, loader, 
     vars(opt))
 


### PR DESCRIPTION
it makes the eval_utils.py load always the MS COCO dataset, in the line `dataset = eval_kwargs.get('dataset', 'coco')`